### PR TITLE
Make it more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ There are many potential pitfalls to this approach. Please open an issue if you 
    git pull --tags
    ```
 
-* ### `Unknown version source: vcs`
-
-   Install `hatch-vcs` in your development environment.
-
-   If you see this in your production environment, then uninstall `hatchling`.
-
 * ### `ValueError: A distribution name is required.`
 
    This occurs when the `__package__` variable is not set. Always ensure that you invoke your package as a module.
@@ -99,9 +93,6 @@ There are many potential pitfalls to this approach. Please open an issue if you 
 
    (The latter should only be used for running scripts that are not part of a package!)
 
-* ### `LookupError: Error getting the version from source `vcs`: setuptools-scm was unable to detect version`
-
-   This can occur if `git` is not correctly installed.
 
 * ### `ImportError: cannot import name '__version__' from partially initialized module '...' (most likely due to a circular import)`
 
@@ -139,7 +130,7 @@ There are many potential pitfalls to this approach. Please open an issue if you 
 
 * ### `ImportError: attempted relative import with no known parent package`
 
-   Ensure that the project is properly installed, e.g. by running `pip install -editable .`.
+   Ensure that the project is properly installed, e.g. by running `pip install --editable .`.
 
 * ### `ModuleNotFoundError: No module named 'importlib.metadata'`
 

--- a/hatch_vcs_footgun_example/version.py
+++ b/hatch_vcs_footgun_example/version.py
@@ -12,6 +12,7 @@ def _get_hatch_version():
 
     try:
         from hatchling.metadata.core import ProjectMetadata
+        from hatchling.plugin.exceptions import UnknownPluginError
         from hatchling.plugin.manager import PluginManager
         from hatchling.utils.fs import locate_file
     except ImportError:
@@ -24,8 +25,13 @@ def _get_hatch_version():
         raise RuntimeError("pyproject.toml not found although hatchling is installed")
     root = os.path.dirname(pyproject_toml)
     metadata = ProjectMetadata(root=root, plugin_manager=PluginManager())
-    # Version can be either statically set in pyproject.toml or computed dynamically:
-    return metadata.core.version or metadata.hatch.version.cached
+    try:
+        # Version can be either statically set in pyproject.toml or computed dynamically:
+        return metadata.core.version or metadata.hatch.version.cached
+    except (LookupError, UnknownPluginError):
+        # LookupError: Git is probably not correctly installed
+        # UnknownPluginError: Hatchling is installed but `hatch-vcs` isn’t
+        return None
 
 
 def _get_importlib_metadata_version():


### PR DESCRIPTION
If this is robust against `hatchling` not being installed, it should also be robust against `hatchling` being installed without `hatch-vcs`. Maybe someone uses the library this code is in inside of some other hatch plugin or so!

Similarly the `LookupError` probably occurs on CI or a production environment or so where installing or configuring git just to have this not crash would feel like a hassle, so we should catch that too.

I think the other problems are more genuine user errors that we shouldn’t protect against.