### PR TITLE
Simplify pyproject.toml to minimal illustrative example

### DIFF
--- a/.github/workflows/prepare_pypi_readme.py
+++ b/.github/workflows/prepare_pypi_readme.py
@@ -13,6 +13,9 @@ if "readme" not in dynamic:
 pyproject["project"]["dynamic"] = dynamic
 
 pyproject["project"]["license"] = {"file": "LICENSE"}
+pyproject["project"]["urls"] = {
+    "Homepage": "https://github.com/maresb/hatch-vcs-footgun-example"
+}
 
 build_system_requires = pyproject["build-system"].get("requires", [])
 if "hatch-fancy-pypi-readme" not in build_system_requires:

--- a/.github/workflows/prepare_pypi_readme.py
+++ b/.github/workflows/prepare_pypi_readme.py
@@ -12,6 +12,8 @@ if "readme" not in dynamic:
     dynamic.append("readme")
 pyproject["project"]["dynamic"] = dynamic
 
+pyproject["project"]["license"] = {"file": "LICENSE"}
+
 build_system_requires = pyproject["build-system"].get("requires", [])
 if "hatch-fancy-pypi-readme" not in build_system_requires:
     build_system_requires.append("hatch-fancy-pypi-readme")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ name = "hatch-vcs-footgun-example"
 dynamic = ["version"]
 readme = "README.md"
 
-[project.urls]
-Homepage = "https://github.com/maresb/hatch-vcs-footgun-example"
-
 [tool.hatch.version]
 source = "vcs"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# This is an illustrative minimal pyproject.toml.
+# NOTE: CI mutates this file for PyPI; see `.github/workflows/prepare_pypi_readme.py`.
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "hatch-vcs-footgun-example"
 dynamic = ["version"]
 readme = "README.md"
-license = { file = "LICENSE" }
 
 [project.urls]
 Homepage = "https://github.com/maresb/hatch-vcs-footgun-example"


### PR DESCRIPTION
## Summary
- Add comments clarifying that `pyproject.toml` is an illustrative minimal example mutated by CI
- Move `license` and `project.urls` metadata to `prepare_pypi_readme.py` so they're added during CI

## Motivation
The checked-in `pyproject.toml` serves as an example for users. Keeping it minimal makes it clearer what fields are actually required. Non-essential metadata (`license`, `urls`) is still included in the published package via the CI script.

## Test plan
- [x] Verified local build succeeds after running `prepare_pypi_readme.py`
- [x] Confirmed wheel metadata includes `License` and `Project-URL`