### PR TITLE
Fix: chdir to project root for PEP 517 compliance

### DIFF
--- a/hatch_vcs_footgun_example/version.py
+++ b/hatch_vcs_footgun_example/version.py
@@ -8,6 +8,7 @@ from this module into your `__init__.py` file and elsewhere in your project.
 """
 
 import os
+from pathlib import Path
 
 
 def _get_hatch_version():
@@ -22,8 +23,8 @@ def _get_hatch_version():
     pyproject_toml = locate_file(__file__, "pyproject.toml")
     if pyproject_toml is None:
         raise RuntimeError("pyproject.toml not found although hatchling is installed")
-    root = os.path.dirname(pyproject_toml)
-    metadata = ProjectMetadata(root=root, plugin_manager=PluginManager())
+    root = Path(pyproject_toml).parent
+    metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
     # Version can be either statically set in pyproject.toml or computed dynamically:
     return metadata.core.version or metadata.hatch.version.cached
 

--- a/hatch_vcs_footgun_example/version.py
+++ b/hatch_vcs_footgun_example/version.py
@@ -24,9 +24,16 @@ def _get_hatch_version():
     if pyproject_toml is None:
         raise RuntimeError("pyproject.toml not found although hatchling is installed")
     root = Path(pyproject_toml).parent
-    metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
-    # Version can be either statically set in pyproject.toml or computed dynamically:
-    return metadata.core.version or metadata.hatch.version.cached
+
+    # Temporarily set cwd to project root for PEP 517 compliance.
+    old_cwd = Path.cwd()
+    os.chdir(root)
+    try:
+        metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
+        # Version can be static in pyproject.toml or computed dynamically:
+        return metadata.core.version or metadata.hatch.version.cached
+    finally:
+        os.chdir(old_cwd)
 
 
 def _get_importlib_metadata_version():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,7 +2,14 @@ import os
 import sys
 from textwrap import dedent
 
-from setup_venv import get_package_path, install_editable, run_git, run_python
+import pytest
+
+from setup_venv import (  # isort: skip
+    get_package_path,
+    install_editable,
+    run_git,
+    run_python,
+)
 
 
 def test_version_without_install(project):
@@ -231,6 +238,91 @@ def test_circular_import(project):
         ]
     for expected_string in expected_strings:
         assert expected_string in result.stderr
+
+
+def test_cwd_not_in_project_root(project):
+    """Test runtime version computation when cwd != project root.
+
+    `_get_hatch_version()` uses Hatchling's `ProjectMetadata`, which can execute
+    Hatch metadata hooks (notably `hatch-fancy-pypi-readme`) while evaluating
+    dynamic fields. Those hooks are written for the PEP 517 build environment,
+    where the frontend is required to set the current working directory to the
+    project root.
+
+    When this version computation is triggered at runtime from some other cwd,
+    hooks may look for files like `README.md` relative to the *current cwd* and
+    fail with errors like:
+
+    - `ConfigurationError: ["Fragment file 'README.md' not found."]`
+
+    To avoid surprising failures, runtime version computation must ensure
+    PEP 517-like behavior by temporarily chdir'ing to the project root while
+    reading `ProjectMetadata`.
+    """
+    # Skip _version.py variant - it doesn't use _get_hatch_version at runtime
+    if project["version_source"] == "_version.py":
+        pytest.skip("_version.py doesn't use runtime hatch version computation")
+
+    # Configure hatch-fancy-pypi-readme to trigger the cwd bug
+    pyproject = project["path"] / "pyproject.toml"
+    content = pyproject.read_text()
+
+    # Add hatch-fancy-pypi-readme to build requirements
+    content = content.replace(
+        'requires = ["hatchling", "hatch-vcs"]',
+        'requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]',
+    )
+
+    # Change readme from static to dynamic
+    content = content.replace('readme = "README.md"', "")
+    if '"readme"' not in content:
+        content = content.replace(
+            'dynamic = ["version"]', 'dynamic = ["version", "readme"]'
+        )
+
+    # Add hatch-fancy-pypi-readme configuration
+    content += dedent(
+        """
+        [tool.hatch.metadata.hooks.fancy-pypi-readme]
+        content-type = "text/markdown"
+
+        [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+        path = "README.md"
+        """
+    )
+    pyproject.write_text(content)
+
+    # Install hatch-fancy-pypi-readme in the venv, then install the project
+    run_python(
+        [project["python"], "-m", "pip", "install", "hatch-fancy-pypi-readme"],
+        cwd=project["path"],
+    )
+    install_editable(project)
+
+    # Create a subdirectory to run from
+    notebooks_dir = project["path"] / "notebooks"
+    notebooks_dir.mkdir(exist_ok=True)
+
+    # Run with HATCH_VCS_RUNTIME_VERSION set from the subdirectory
+    env = os.environ.copy()
+    env["MYPROJECT_HATCH_VCS_RUNTIME_VERSION"] = "1"
+
+    result = run_python(
+        [project["python"], "-m", "hatch_vcs_footgun_example.main"],
+        cwd=notebooks_dir,  # Run from subdirectory, not project root
+        env=env,
+        check=False,
+    )
+
+    # Print output for debugging
+    print(f"\nstdout: {result.stdout}")
+    print(f"\nstderr: {result.stderr}")
+
+    # Should succeed - version should be computed correctly
+    # Before the fix, this fails with:
+    # ConfigurationError: ["Fragment file 'README.md' not found."]
+    assert result.returncode == 0, f"Expected success but got: {result.stderr}"
+    assert "My version is '100.2." in result.stdout
 
 
 def test_missing_tags_cause_incorrect_version(project, tmp_path):


### PR DESCRIPTION
## Summary

- Refactor to use pathlib for path operations
- Add test for runtime version computation when cwd != project root
- Fix by temporarily chdir'ing to project root while evaluating `ProjectMetadata`

Fixes #13